### PR TITLE
Custom logger: Fix defaulting + blank-fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,13 +59,17 @@ module.exports = function CaptainsLog ( overrides ) {
 		// Fill in the gaps for the required log methods with
 		// reasonable guesses if the custom logger is missing any
 		// (only required method is `logger.log` or `logger.debug`)
-		logger.debug = logger.debug || logger.log;
-		logger.info = logger.info || logger.log;
-		logger.warn = logger.warn || logger.error || logger.log;
-		logger.error = logger.error || logger.log;
-		logger.crit = logger.crit || logger.error;
-		logger.verbose = logger.verbose || logger.log;
-		logger.silly = logger.silly || logger.log;
+		// If no reasonable alternative is possible, don't log
+		var nullLog = function(msg) { };
+		
+		logger.debug = logger.debug || nullLog;
+		logger.info = logger.info || nullLog;
+		logger.warn = logger.warn || logger.error || nullLog;
+		logger.error = logger.error || nullLog;
+		logger.crit = logger.crit || logger.error || nullLog;
+		logger.verbose = logger.verbose || nullLog;
+		logger.silly = logger.silly || nullLog;
+		logger.blank = logger.blank || nullLog;
 	}
 
 	// Make logger callable and stuff (wrap it)


### PR DESCRIPTION
Before the logger.log method was used when the given custom logger does not support the log-level. This actually does not work and breaks when executed, because the log-function seems to expect a this-context when being executed (All calls are internally wrapped to [this](https://github.com/flatiron/winston/blob/master/lib/winston/common.js#L43)). 

Also, blank defaulting was missing, which leads to a crash, even when using a simple console logger as custom logger:

``` js
var customLogger = new winston.Logger({
    transports: [
        new winston.transports.Console({ level: 'silly' })
    ]
});
```
