### PR TITLE
Fix for issue #14 (fixing log prefix with custom logger)

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -98,11 +98,17 @@ module.exports = function(overrides) {
         configuredPrefix = '';
       }
 
-			// Else default prefix for each log level to whatever's in the `prefixes conf
-			// As long as a custom logger was not specified
-			else if (!options.custom) {
-				configuredPrefix = prefixes[logAt];
-			}
+      // Else default prefix for each log level to whatever's in the `prefixes conf`
+      // As long as a custom logger was not specified
+      else if (!options.custom) {
+        configuredPrefix = configuredPrefix || prefixes[logAt];
+      }
+			
+      // Else if there is a custom logger and prefix is set to true
+      // Set the prefix to the default from `prefixes.conf`
+      else if (options.prefix === true) {
+        configuredPrefix = prefixes[logAt];
+      }
 
       // Add some color
       var colorizedPrefix = (function() {

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -98,9 +98,11 @@ module.exports = function(overrides) {
         configuredPrefix = '';
       }
 
-      // Default prefix for each log level to whatever's in the `prefixes conf,
-      // as long as no explicit global prefix was defined.
-      configuredPrefix = configuredPrefix || prefixes[logAt];
+			// Else default prefix for each log level to whatever's in the `prefixes conf
+			// As long as a custom logger was not specified
+			else if (!options.custom) {
+				configuredPrefix = prefixes[logAt];
+			}
 
       // Add some color
       var colorizedPrefix = (function() {

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -99,13 +99,13 @@ module.exports = function(overrides) {
       }
 
       // Else default prefix for each log level to whatever's in the `prefixes conf`
-      // As long as a custom logger was not specified
+      // As long as a custom logger is not specified
       else if (!options.custom) {
         configuredPrefix = configuredPrefix || prefixes[logAt];
       }
 			
       // Else if there is a custom logger and prefix is set to true
-      // Set the prefix to the default from `prefixes.conf`
+      // Set the prefix for each log level to the defaults from `prefixes.conf`
       else if (options.prefix === true) {
         configuredPrefix = prefixes[logAt];
       }


### PR DESCRIPTION
See issue #14.

These changes create the following behavior (I made sure to test each scenario described below):

Without a custom logger, everything should work the same, except that it only sets the default prefix if `options.prefix` is not `false` or `null`.

With a custom logger and no prefix defined, no prefixes are set and relies on the custom logger to handle its on prefixes (probably preferred behavior with most custom loggers).

With a custom logger and `options.prefix` defined to `true` it adds the default prefixes before passing the message to the custom logger (this option might result in duplicate prefixes like described in the issue if the custom logger has its own prefixes, but it would be useful if the custom logger did not have it's own prefixes).

With a custom logger and options.prefix is defined as a string, the string prefix is prepended to the message sent to the custom logger.