### PR TITLE
Enable colored prefixes by default in production (now that we've swit…

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -113,9 +113,8 @@ module.exports = function(overrides) {
 
   // If `prefixes` were not explicitly set in user config,
   // and `colors` were not disabled in user config,
-  // and NODE_ENV is not set to 'production,
-  // load the `colors` dependency and colorize prefixes.
-  if (options.prefixes === undefined && options.colors && process.env.NODE_ENV !== 'production') {
+  // display colorized prefixes.
+  if (options.prefixes === undefined && options.colors) {
 
     options.prefixes = {};
 


### PR DESCRIPTION
…ched dependencies, there is no material performance advantage to not doing this.  And it's prettier this way.)