### PR TITLE
Use default colorName on configure captains-log

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -153,7 +153,7 @@ module.exports = function(overrides) {
 
       // Use the appropriate color for the log level.
       var colorMappings = _.isObject(options.colors) ? options.colors : {};
-      var colorName = colorMappings[logAt];
+      var colorName = colorMappings[logAt] || DEFAULT.OVERRIDES.colors[logAt];
 
       // Get the ANSI-colorized prefix.
       var colorizedPrefix = (function _getColorizedPrefix() {


### PR DESCRIPTION
There's an error when use `captains-log` with Mocha 5, maybe due how mocha mocks/intercepts console logging (I don't know for sure).
This change doesn't add or modify any current features.

fixes balderdashy/sails/#4395