### PR TITLE
Upgrade rc to ~1.2.8 to fix deep-extend vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "chalk": "1.1.3",
     "@sailshq/lodash": "^3.10.2",
-    "rc": "1.0.1",
+    "rc": "~1.2.8",
     "semver": "5.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade `rc` package to `~1.2.8` to fix the prototype pollution vulnerability in the `deep-extend` package

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ deep-extend                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=0.5.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ sails                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ sails > captains-log > rc > deep-extend                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/612                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```