### PR TITLE
Bind the custom logger to the log methods, useful for loggers that use "this" on their own log methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,14 +65,14 @@ module.exports = function CaptainsLog(overrides) {
     // If no reasonable alternative is possible, don't log
     var nullLog = function() {};
 
-    logger.debug = logger.debug || nullLog;
-    logger.info = logger.info || nullLog;
-    logger.warn = logger.warn || logger.error || nullLog;
-    logger.error = logger.error || nullLog;
-    logger.crit = logger.crit || logger.error || nullLog;
-    logger.verbose = logger.verbose || nullLog;
-    logger.silly = logger.silly || nullLog;
-    logger.blank = logger.blank || nullLog;
+    logger.debug = logger.debug ? logger.debug.bind(logger) : nullLog;
+    logger.info = logger.info ? logger.info.bind(logger) : nullLog;
+    logger.error = logger.error ? logger.error.bind(logger) : nullLog;
+    logger.warn = logger.warn ? logger.warn.bind(logger) : logger.error;
+    logger.crit = logger.crit ? logger.crit.bind(logger) : logger.error;
+    logger.verbose = logger.verbose ? logger.verbose.bind(logger) : nullLog;
+    logger.silly = logger.silly ? logger.silly.bind(logger) : nullLog;
+    logger.blank = logger.blank ? logger.blank.bind(logger) : nullLog;
   }
 
   // Make logger callable and stuff (wrap it)

--- a/index.js
+++ b/index.js
@@ -63,16 +63,15 @@ module.exports = function CaptainsLog(overrides) {
     // reasonable guesses if the custom logger is missing any
     // (only required method is `logger.log` or `logger.debug`)
     // If no reasonable alternative is possible, don't log
-    var nullLog = function() {};
 
-    logger.debug = logger.debug ? logger.debug.bind(logger) : nullLog;
-    logger.info = logger.info ? logger.info.bind(logger) : nullLog;
-    logger.error = logger.error ? logger.error.bind(logger) : nullLog;
-    logger.warn = logger.warn ? logger.warn.bind(logger) : logger.error;
-    logger.crit = logger.crit ? logger.crit.bind(logger) : logger.error;
-    logger.verbose = logger.verbose ? logger.verbose.bind(logger) : nullLog;
-    logger.silly = logger.silly ? logger.silly.bind(logger) : nullLog;
-    logger.blank = logger.blank ? logger.blank.bind(logger) : nullLog;
+    logger.debug = logger.debug ? logger.debug.bind(logger) : _.noop;
+    logger.info = logger.info ? logger.info.bind(logger) : _.noop;
+    logger.error = logger.error ? logger.error.bind(logger) : _.noop;
+    logger.warn = logger.warn ? logger.warn.bind(logger) : (logger.error ? logger.error.bind(logger) : _.noop);
+    logger.crit = logger.crit ? logger.crit.bind(logger) : (logger.error ? logger.error.bind(logger) : _.noop);
+    logger.verbose = logger.verbose ? logger.verbose.bind(logger) : _.noop;
+    logger.silly = logger.silly ? logger.silly.bind(logger) : _.noop;
+    logger.blank = logger.blank ? logger.blank.bind(logger) : _.noop;
   }
 
   // Make logger callable and stuff (wrap it)


### PR DESCRIPTION
Bind the custom logger to the log methods, useful for loggers that use "this" on their own log methods

While using the latest winston 3.2.1, issues arise throwing error `self._addDefaultMeta is not a function`  as reported in https://github.com/balderdashy/sails/issues/4601

This fixes the issue